### PR TITLE
Allow comments and password to be null

### DIFF
--- a/src/Dto/StreamerDto.php
+++ b/src/Dto/StreamerDto.php
@@ -18,7 +18,7 @@ class StreamerDto implements JsonSerializable
     protected $username;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $password;
 
@@ -28,7 +28,7 @@ class StreamerDto implements JsonSerializable
     protected $displayName;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $comments;
 
@@ -45,18 +45,18 @@ class StreamerDto implements JsonSerializable
     /**
      * @param int $id
      * @param string $username
-     * @param string $password
+     * @param string|null $password
      * @param string $displayName
-     * @param string $comments
+     * @param string|null $comments
      * @param bool $isActive
      * @param LinksDto $links
      */
     public function __construct(
         int $id,
         string $username,
-        string $password,
+        ?string $password,
         string $displayName,
-        string $comments,
+        ?string $comments,
         bool $isActive,
         LinksDto $links
     ) {
@@ -122,7 +122,7 @@ class StreamerDto implements JsonSerializable
      *
      * @return StreamerDto
      */
-    function setPassword(string $password): StreamerDto
+    function setPassword(?string $password): StreamerDto
     {
         $this->password = $password;
 
@@ -162,7 +162,7 @@ class StreamerDto implements JsonSerializable
      *
      * @return StreamerDto
      */
-    function setComments(string $comments): StreamerDto
+    function setComments(?string $comments): StreamerDto
     {
         $this->comments = $comments;
 


### PR DESCRIPTION

Fixes #15 Allow comments and password to be null as the API may not always pass these parameters back as a string and can cause error.