### PR TITLE
Update PHP and Guzzle versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,20 +16,20 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4",
         "ext-json": "*",
         "ext-gd": "*",
 
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.8",
-        "overtrue/phplint": "^1.1",
-        "phpstan/phpstan": "^0.11.1",
-        "phpstan/phpstan-strict-rules": "^0.11.0",
-        "phpunit/phpunit": "^7.5",
+        "overtrue/phplint": "^2.2.0",
+        "phpstan/phpstan": "^0.12.54",
+        "phpstan/phpstan-strict-rules": "^0.12.5",
+        "phpunit/phpunit": "^9.4.2",
         "roave/security-advisories": "dev-master",
-        "vlucas/phpdotenv": "^3.4"
+        "vlucas/phpdotenv": "^5.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     },
     "require-dev": {
         "fzaninotto/faker": "^1.8",
-        "overtrue/phplint": "^2.2.0",
-        "phpstan/phpstan": "^0.12.54",
-        "phpstan/phpstan-strict-rules": "^0.12.5",
-        "phpunit/phpunit": "^9.4.2",
+        "overtrue/phplint": "^1.1",
+        "phpstan/phpstan": "^0.11.1",
+        "phpstan/phpstan-strict-rules": "^0.11.0",
+        "phpunit/phpunit": "^7.5",
         "roave/security-advisories": "dev-master",
-        "vlucas/phpdotenv": "^5.2.0"
+        "vlucas/phpdotenv": "^3.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This fix should hopefully resolve issues installing the php-api-client.

I do note that some of the require-dev are no longer in use, specifically fzaninotto/faker, might be best to seek out an alternative.