### PR TITLE
API Client doesn't set accept content type

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -83,6 +83,8 @@ class Client extends AbstractClient
 
         $options['allow_redirects'] = true;
         $options['http_errors'] = false;
+        $options['headers']['accept'] = 'application/json';
+
 
         if (null !== $apiKey) {
             $options['headers']['Authorization'] = 'Bearer ' . $apiKey;


### PR DESCRIPTION
Api requests are made without setting 'accept' header. This works for the happy path however when you make a request with an incorrect API Key you get a generic login page instead of the expected exception thrown. The API client tries to parse HTML and throws a bunch of errors.

I am going to work around the problem by injecting my own guzzle client but hope this is enough to point you guys in the right direction! 

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
Exception not thrown for wrong API Key on protected routes.

**Proposed changes:**
Add header to all requests always as the library is not prepared for other content types.