### PR TITLE
Allow null listen URL in StationDTO

### DIFF
--- a/src/Dto/StationDto.php
+++ b/src/Dto/StationDto.php
@@ -36,7 +36,7 @@ class StationDto
     protected $backend;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $listenUrl;
 
@@ -62,7 +62,7 @@ class StationDto
      * @param string $description
      * @param string $frontend
      * @param string $backend
-     * @param string $listenUrl
+     * @param string|null $listenUrl
      * @param bool $isPublic
      * @param MountDto[] $mounts
      * @param RemoteDto[] $remotes
@@ -74,7 +74,7 @@ class StationDto
         string $description,
         string $frontend,
         string $backend,
-        string $listenUrl,
+        ?string $listenUrl,
         bool $isPublic,
         array $mounts,
         array $remotes
@@ -212,19 +212,19 @@ class StationDto
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getListenUrl(): string
+    public function getListenUrl(): ?string
     {
         return $this->listenUrl;
     }
 
     /**
-     * @param string $listenUrl
+     * @param string|null $listenUrl
      *
      * @return StationDto
      */
-    public function setListenUrl(string $listenUrl): StationDto
+    public function setListenUrl(?string $listenUrl): StationDto
     {
         $this->listenUrl = $listenUrl;
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**


**Proposed changes:**
When a station only connects to a remote server, the listen URL of the station is null. This returns a null value in the listen_url parameter in the API.
This PR changes listenUrl property in StationDto object to allow null values.
